### PR TITLE
removes  "block declaration is not a prototype" warning

### DIFF
--- a/Common.h
+++ b/Common.h
@@ -86,7 +86,7 @@
 
 // the [aBlock copy] fixes a crash on macOS Sierra (Espionage issue #399)
 #define INMAINWAIT(...) do { \
-    void(^aBlock)() = ^{ \
+    void(^aBlock)(void) = ^{ \
         __VA_ARGS__; \
     }; \
     if ( __unlikely([NSThread isMainThread]) ) \


### PR DESCRIPTION
as title says